### PR TITLE
Expose raw named pipe

### DIFF
--- a/PipeMethodCalls/Endpoints/PipeClient.cs
+++ b/PipeMethodCalls/Endpoints/PipeClient.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq.Expressions;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -75,6 +72,22 @@ namespace PipeMethodCalls
 			this.impersonationLevel = impersonationLevel;
 			this.inheritability = inheritability;
 		}
+		
+		/// <summary>
+		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
+		/// </summary>
+		public NamedPipeClientStream PipeInstance
+		{
+			get
+			{
+				if (this.rawPipeStream == null)
+				{
+					CreatePipe();
+				}
+
+				return this.rawPipeStream;
+			}
+		}
 
 		/// <summary>
 		/// Gets the state of the pipe.
@@ -110,13 +123,9 @@ namespace PipeMethodCalls
 
 			this.logger.Log(() => $"Connecting to named pipe '{this.pipeName}' on machine '{this.serverName}'");
 
-			if (this.options != null)
+			if (this.rawPipeStream == null)
 			{
-				this.rawPipeStream = new NamedPipeClientStream(this.serverName, this.pipeName, PipeDirection.InOut, this.options.Value | PipeOptions.Asynchronous, this.impersonationLevel.Value, this.inheritability.Value);
-			}
-			else
-			{
-				this.rawPipeStream = new NamedPipeClientStream(this.serverName, this.pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+				CreatePipe();	
 			}
 
 			await this.rawPipeStream.ConnectAsync(cancellationToken).ConfigureAwait(false);
@@ -137,6 +146,23 @@ namespace PipeMethodCalls
 		public Task WaitForRemotePipeCloseAsync(CancellationToken cancellationToken = default)
 		{
 			return this.messageProcessor.WaitForRemotePipeCloseAsync(cancellationToken);
+		}
+		
+		/// <summary>
+		/// Initialize new named pipe stream with preset options respected
+		/// </summary>
+		private void CreatePipe()
+		{
+			if (this.options != null)
+			{
+				this.rawPipeStream = new NamedPipeClientStream(this.serverName, this.pipeName, PipeDirection.InOut,
+					this.options.Value | PipeOptions.Asynchronous, this.impersonationLevel.Value, this.inheritability.Value);
+			}
+			else
+			{
+				this.rawPipeStream = new NamedPipeClientStream(this.serverName, this.pipeName, PipeDirection.InOut,
+					PipeOptions.Asynchronous);
+			}
 		}
 
 		#region IDisposable Support

--- a/PipeMethodCalls/Endpoints/PipeClient.cs
+++ b/PipeMethodCalls/Endpoints/PipeClient.cs
@@ -76,13 +76,13 @@ namespace PipeMethodCalls
 		/// <summary>
 		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
 		/// </summary>
-		public NamedPipeClientStream PipeInstance
+		public NamedPipeClientStream RawPipe
 		{
 			get
 			{
 				if (this.rawPipeStream == null)
 				{
-					CreatePipe();
+					this.CreatePipe();
 				}
 
 				return this.rawPipeStream;
@@ -125,7 +125,7 @@ namespace PipeMethodCalls
 
 			if (this.rawPipeStream == null)
 			{
-				CreatePipe();	
+				this.CreatePipe();	
 			}
 
 			await this.rawPipeStream.ConnectAsync(cancellationToken).ConfigureAwait(false);

--- a/PipeMethodCalls/Endpoints/PipeClientWithCallback.cs
+++ b/PipeMethodCalls/Endpoints/PipeClientWithCallback.cs
@@ -85,13 +85,13 @@ namespace PipeMethodCalls
 		/// <summary>
 		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
 		/// </summary>
-		public NamedPipeClientStream PipeInstance
+		public NamedPipeClientStream RawPipe
 		{
 			get
 			{
 				if (this.rawPipeStream == null)
 				{
-					CreatePipe();
+					this.CreatePipe();
 				}
 
 				return this.rawPipeStream;
@@ -134,7 +134,7 @@ namespace PipeMethodCalls
 
 			if (this.rawPipeStream == null)
 			{
-				CreatePipe();	
+				this.CreatePipe();	
 			}
 
 			await this.rawPipeStream.ConnectAsync(cancellationToken).ConfigureAwait(false);

--- a/PipeMethodCalls/Endpoints/PipeServer.cs
+++ b/PipeMethodCalls/Endpoints/PipeServer.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,6 +32,22 @@ namespace PipeMethodCalls
 			this.handlerFactoryFunc = handlerFactoryFunc;
 			this.options = options;
 		}
+		
+		/// <summary>
+		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
+		/// </summary>
+		public NamedPipeServerStream PipeInstance
+		{
+			get
+			{
+				if (this.rawPipeStream == null)
+				{
+					CreatePipe();
+				}
+
+				return this.rawPipeStream;
+			}
+		}
 
 		/// <summary>
 		/// Gets the state of the pipe.
@@ -56,19 +70,10 @@ namespace PipeMethodCalls
 		/// <exception cref="IOException">Thrown when the connection fails.</exception>
 		public async Task WaitForConnectionAsync(CancellationToken cancellationToken = default)
 		{
-			PipeOptions pipeOptionsToPass;
-			if (this.options == null)
+			if (this.rawPipeStream == null)
 			{
-				pipeOptionsToPass = PipeOptions.Asynchronous;
+				CreatePipe();	
 			}
-			else
-			{
-				pipeOptionsToPass = this.options.Value | PipeOptions.Asynchronous;
-			}
-
-			this.rawPipeStream = new NamedPipeServerStream(this.pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, pipeOptionsToPass);
-
-			this.logger.Log(() => $"Set up named pipe server '{this.pipeName}'.");
 
 			await this.rawPipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
 
@@ -89,6 +94,27 @@ namespace PipeMethodCalls
 		public Task WaitForRemotePipeCloseAsync(CancellationToken cancellationToken = default)
 		{
 			return this.messageProcessor.WaitForRemotePipeCloseAsync(cancellationToken);
+		}
+
+		/// <summary>
+		/// Initialize new named pipe stream with preset options respected
+		/// </summary>
+		private void CreatePipe()
+		{
+			PipeOptions pipeOptionsToPass;
+			if (this.options == null)
+			{
+				pipeOptionsToPass = PipeOptions.Asynchronous;
+			}
+			else
+			{
+				pipeOptionsToPass = this.options.Value | PipeOptions.Asynchronous;
+			}
+
+			this.rawPipeStream = new NamedPipeServerStream(this.pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte,
+				pipeOptionsToPass);
+
+			this.logger.Log(() => $"Set up named pipe server '{this.pipeName}'.");
 		}
 
 		#region IDisposable Support

--- a/PipeMethodCalls/Endpoints/PipeServer.cs
+++ b/PipeMethodCalls/Endpoints/PipeServer.cs
@@ -36,13 +36,13 @@ namespace PipeMethodCalls
 		/// <summary>
 		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
 		/// </summary>
-		public NamedPipeServerStream PipeInstance
+		public NamedPipeServerStream RawPipe
 		{
 			get
 			{
 				if (this.rawPipeStream == null)
 				{
-					CreatePipe();
+					this.CreatePipe();
 				}
 
 				return this.rawPipeStream;
@@ -72,7 +72,7 @@ namespace PipeMethodCalls
 		{
 			if (this.rawPipeStream == null)
 			{
-				CreatePipe();	
+				this.CreatePipe();	
 			}
 
 			await this.rawPipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/PipeMethodCalls/Endpoints/PipeServerWithCallback.cs
+++ b/PipeMethodCalls/Endpoints/PipeServerWithCallback.cs
@@ -38,13 +38,13 @@ namespace PipeMethodCalls
 		/// <summary>
 		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
 		/// </summary>
-		public NamedPipeServerStream PipeInstance
+		public NamedPipeServerStream RawPipe
 		{
 			get
 			{
 				if (this.rawPipeStream == null)
 				{
-					CreatePipe();
+					this.CreatePipe();
 				}
 
 				return this.rawPipeStream;
@@ -80,7 +80,7 @@ namespace PipeMethodCalls
 		{
 			if (this.rawPipeStream == null)
 			{
-				CreatePipe();	
+				this.CreatePipe();	
 			}
 
 			await this.rawPipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/PipeMethodCalls/Endpoints/PipeServerWithCallback.cs
+++ b/PipeMethodCalls/Endpoints/PipeServerWithCallback.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq.Expressions;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,6 +34,22 @@ namespace PipeMethodCalls
 			this.handlerFactoryFunc = handlerFactoryFunc;
 			this.options = options;
 		}
+		
+		/// <summary>
+		/// Get the raw named pipe. This will automatically create if it hasn't been instantiated yet and is accessed.
+		/// </summary>
+		public NamedPipeServerStream PipeInstance
+		{
+			get
+			{
+				if (this.rawPipeStream == null)
+				{
+					CreatePipe();
+				}
+
+				return this.rawPipeStream;
+			}
+		}
 
 		/// <summary>
 		/// Gets the state of the pipe.
@@ -65,19 +78,10 @@ namespace PipeMethodCalls
 		/// <exception cref="IOException">Thrown when the connection fails.</exception>
 		public async Task WaitForConnectionAsync(CancellationToken cancellationToken = default)
 		{
-			PipeOptions pipeOptionsToPass;
-			if (this.options == null)
+			if (this.rawPipeStream == null)
 			{
-				pipeOptionsToPass = PipeOptions.Asynchronous;
+				CreatePipe();	
 			}
-			else
-			{
-				pipeOptionsToPass = this.options.Value | PipeOptions.Asynchronous;
-			}
-
-			this.rawPipeStream = new NamedPipeServerStream(this.pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, pipeOptionsToPass);
-
-			this.logger.Log(() => $"Set up named pipe server '{this.pipeName}'.");
 
 			await this.rawPipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
 
@@ -99,6 +103,27 @@ namespace PipeMethodCalls
 		public Task WaitForRemotePipeCloseAsync(CancellationToken cancellationToken = default)
 		{
 			return this.messageProcessor.WaitForRemotePipeCloseAsync(cancellationToken);
+		}
+		
+		/// <summary>
+		/// Initialize new named pipe stream with preset options respected
+		/// </summary>
+		private void CreatePipe()
+		{
+			PipeOptions pipeOptionsToPass;
+			if (this.options == null)
+			{
+				pipeOptionsToPass = PipeOptions.Asynchronous;
+			}
+			else
+			{
+				pipeOptionsToPass = this.options.Value | PipeOptions.Asynchronous;
+			}
+
+			this.rawPipeStream = new NamedPipeServerStream(this.pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte,
+				pipeOptionsToPass);
+
+			this.logger.Log(() => $"Set up named pipe server '{this.pipeName}'.");
 		}
 
 		#region IDisposable Support


### PR DESCRIPTION
This set of changes focused on exposing the underlying "raw pipe."  This is to enable more advanced use-cases.  In testing, I've simply used this to print out the default security descriptor.

This is **not** a solution for _setting_ pipe security, unfortunately.  (I am in the process of working on a solution to it, however, and hope to create a PR for feedback)

Notes of how this was implemented:
• The property is called `PipeInstance` on all types (Client, Server, and their respective Callback variants)
• This property is get only
• If the raw pipe doesn't yet exist; it will create it