### PR TITLE
Fixed issue with VoidTaskResult with the MessagePack serializer

### DIFF
--- a/PipeMethodCalls.MessagePack/MessagePackPipeSerializer.cs
+++ b/PipeMethodCalls.MessagePack/MessagePackPipeSerializer.cs
@@ -23,7 +23,7 @@ namespace PipeMethodCalls.MessagePack
 
 		public byte[] Serialize(object o)
 		{
-			if (o == null)
+			if (o == null || o.GetType().FullName == "System.Threading.Tasks.VoidTaskResult")
 			{
 				return Array.Empty<byte>();
 			}

--- a/TestCore/Adder.cs
+++ b/TestCore/Adder.cs
@@ -41,6 +41,11 @@ namespace TestCore
         {
         }
 
+		public Task DoesNothingAsync()
+		{
+			return Task.CompletedTask;
+		}
+
 		public void AlwaysFails()
 		{
 			throw new InvalidOperationException("This method always fails.");

--- a/TestCore/IAdder.cs
+++ b/TestCore/IAdder.cs
@@ -19,6 +19,8 @@ namespace TestCore
 
 		void DoesNothing();
 
+		Task DoesNothingAsync();
+
 		void AlwaysFails();
 
 		void HasRefParam(ref int refParam);

--- a/TestScenarioRunner/WithCallbackScenario.cs
+++ b/TestScenarioRunner/WithCallbackScenario.cs
@@ -28,6 +28,7 @@ namespace TestScenarioRunner
 			unwrapResult.ShouldBe(0);
 
 			await pipeClientWithCallback.InvokeAsync(adder => adder.DoesNothing()).ConfigureAwait(false);
+			await pipeClientWithCallback.InvokeAsync(adder => adder.DoesNothingAsync()).ConfigureAwait(false);
 
 			var expectedException = await Should.ThrowAsync<PipeInvokeFailedException>(async () =>
 			{


### PR DESCRIPTION
I tried to go more async and ran into another problem. The core code is getting the result of a `Task` (not `Task<T>`) when it's the special `Task<VoidTaskResult>`. Then it tries to serialize that and MessagePack complains that it doesn't know how to serialize it. This fixes the issue, but it would probably be better for the core code to know it shouldn't be serializing the result when the signature of the method is `void` or `Task`.