### PR TITLE
Update README.md + suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PipeMethodCalls
-Lightweight library for method calls over named and anonymous pipes for IPC in .NET Core. Supports two-way communication with callbacks.
+
+Lightweight .NET Standard 2.0 library to use method calls over named and anonymous pipes for IPC. Supports two-way communication with callbacks.
 
 ### Calls from client to server
 


### PR DESCRIPTION
Rework the library description to identify this as a .NET Standard 2.0 lib, and drop the reference to .NET Core as it is now just known as ".NET".

If these changes look good I would recommend a couple of additional actions:

- Update the GitHub repo description to match.
- Update the NuGet .nuspec description element to match.
- Use the NuGet .nuspec releaseNotes element to store what you are currently putting in the description element (right now the NuGet README is showing the latest release notes instead of a project description)

https://learn.microsoft.com/en-us/nuget/release-notes/nuget-1.5#package-release-notes

https://learn.microsoft.com/en-us/nuget/reference/nuspec#releasenotes