### PR TITLE
Performance Optimization: Conditionally Calling the .Compile() Method on Expression

### DIFF
--- a/PipeMethodCalls.sln
+++ b/PipeMethodCalls.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestRunner", "TestRunner\TestRunner.csproj", "{0BF80523-E47C-457E-ADB4-3BF5428CC10E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{4BEB5599-E924-4342-B6BE-E8EB19FC3EC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4BEB5599-E924-4342-B6BE-E8EB19FC3EC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4BEB5599-E924-4342-B6BE-E8EB19FC3EC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BF80523-E47C-457E-ADB4-3BF5428CC10E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF80523-E47C-457E-ADB4-3BF5428CC10E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF80523-E47C-457E-ADB4-3BF5428CC10E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF80523-E47C-457E-ADB4-3BF5428CC10E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PipeMethodCalls/Invoker/ArgumentResolver.cs
+++ b/PipeMethodCalls/Invoker/ArgumentResolver.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System;
+using System.Linq;
+
+namespace PipeMethodCalls
+{
+    public static class ArgumentResolver
+    {
+        public static object GetValue(Expression expression)
+        {
+            switch (expression)
+            {
+                case null:
+                    return null;
+                case ConstantExpression constantExpression:
+                    return constantExpression.Value;
+                case MemberExpression memberExpression:
+                    return GetValue(memberExpression);
+                case MethodCallExpression methodCallExpression:
+                    return GetValue(methodCallExpression);
+            }
+
+            var lambdaExpression = Expression.Lambda(expression);
+            var @delegate = lambdaExpression.Compile();
+            return @delegate.DynamicInvoke();
+        }
+
+        private static object GetValue(MemberExpression memberExpression)
+        {
+            var value = GetValue(memberExpression.Expression);
+
+            var member = memberExpression.Member;
+            switch (member)
+            {
+                case FieldInfo fieldInfo:
+                    return fieldInfo.GetValue(value);
+                case PropertyInfo propertyInfo:
+                    try
+                    {
+                        return propertyInfo.GetValue(value);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        throw e.InnerException;
+                    }
+                default:
+                    throw new Exception("Unknown member type: " + member.GetType());
+            }
+        }
+
+        private static object GetValue(MethodCallExpression methodCallExpression)
+        {
+            var paras = GetArray(methodCallExpression.Arguments);
+            var obj = GetValue(methodCallExpression.Object);
+
+            try
+            {
+                return methodCallExpression.Method.Invoke(obj, paras);
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        private static object[] GetArray(IEnumerable<Expression> expressions)
+        {
+            return expressions.Select(GetValue).ToArray();
+        }
+    }
+}

--- a/PipeMethodCalls/Invoker/MethodInvoker.cs
+++ b/PipeMethodCalls/Invoker/MethodInvoker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -208,12 +209,12 @@ namespace PipeMethodCalls
 			return await this.GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
 		}
 
-		/// <summary>
-		/// Creates a pipe request from the given expression.
-		/// </summary>
-		/// <param name="expression">The expression to execute.</param>
-		/// <returns>The request to send over the pipe to execute that expression.</returns>
-		private SerializedPipeRequest CreateRequest(Expression expression)
+        /// <summary>
+        /// Creates a pipe request from the given expression.
+        /// </summary>
+        /// <param name="expression">The expression to execute.</param>
+        /// <returns>The request to send over the pipe to execute that expression.</returns>
+        private SerializedPipeRequest CreateRequest(Expression expression)
 		{
 			int callId = Interlocked.Increment(ref this.currentCall);
 
@@ -228,7 +229,7 @@ namespace PipeMethodCalls
 			}
 
 			string methodName = methodCallExp.Method.Name;
-			object[] argumentList = methodCallExp.Arguments.Select(argumentExpression => Expression.Lambda(argumentExpression).Compile().DynamicInvoke()).ToArray();
+			object[] argumentList = methodCallExp.Arguments.Select(ArgumentResolver.GetValue).ToArray();
 			Type[] genericArguments = methodCallExp.Method.GetGenericArguments();
 
 			var typedRequest = new TypedPipeRequest
@@ -272,7 +273,7 @@ namespace PipeMethodCalls
 			return serializedRequest;
 		}
 
-		/// <summary>
+        /// <summary>
 		/// Gets a pipe response for the given pipe request.
 		/// </summary>
 		/// <param name="request">The request to send.</param>

--- a/TestCore/Adder.cs
+++ b/TestCore/Adder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,7 +13,12 @@ namespace TestCore
 			return a + b;
 		}
 
-		public WrappedInt AddWrappedNumbers(WrappedInt a, WrappedInt b)
+        public double Sum(double[] numbers)
+        {
+			return numbers.Sum();
+        }
+
+        public WrappedInt AddWrappedNumbers(WrappedInt a, WrappedInt b)
 		{
 			return new WrappedInt {Num = a.Num + b.Num};
 		}

--- a/TestCore/IAdder.cs
+++ b/TestCore/IAdder.cs
@@ -8,6 +8,7 @@ namespace TestCore
 	public interface IAdder
 	{
 		int AddNumbers(int a, int b);
+        double Sum(double[] numbers);
 
 		WrappedInt AddWrappedNumbers(WrappedInt a, WrappedInt b);
 

--- a/TestCore/Scenario.cs
+++ b/TestCore/Scenario.cs
@@ -7,6 +7,7 @@ namespace TestCore
     public enum Scenario
     {
         WithCallback,
-        NoCallback
+        NoCallback,
+        Performance
     }
 }

--- a/TestRunner/Program.cs
+++ b/TestRunner/Program.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using TestCore;
+
+ProcessStartInfo serverInfo = new ProcessStartInfo("TestScenarioRunner", $"--scenario {Scenario.Performance} --side {PipeSide.Server} --type {PipeSerializerType.MessagePack}");
+Process serverProcess = Process.Start(serverInfo);
+
+var stopwatch = new Stopwatch();
+stopwatch.Start();
+
+ProcessStartInfo clientInfo = new ProcessStartInfo("TestScenarioRunner", $"--scenario {Scenario.Performance} --side {PipeSide.Client} --type {PipeSerializerType.MessagePack}");
+Process clientProcess = Process.Start(clientInfo);
+
+clientProcess.WaitForExit();
+stopwatch.Stop();
+
+var standardError = new StreamWriter(Console.OpenStandardError());
+standardError.AutoFlush = true;
+
+serverProcess.WaitForExit();
+
+//Console.SetError(standardError);
+
+Console.WriteLine();
+Console.WriteLine($@"Time elapsed: {stopwatch.Elapsed.TotalMilliseconds} ms");
+Console.ReadLine();

--- a/TestRunner/TestRunner.csproj
+++ b/TestRunner/TestRunner.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TestScenarioRunner\TestScenarioRunner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestScenarioRunner/PerformanceScenario.cs
+++ b/TestScenarioRunner/PerformanceScenario.cs
@@ -1,0 +1,39 @@
+﻿using PipeMethodCalls;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestCore;
+
+namespace TestScenarioRunner
+{
+    public static class PerformanceScenario
+    {
+		public static async Task RunClientAsync(PipeClient<IAdder> pipeClient)
+		{
+			await pipeClient.ConnectAsync().ConfigureAwait(false);
+
+            double[] numbers = new[] {
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+
+            for (int i = 0; i < 100_000; i++)
+            {
+                var result = pipeClient.Invoker.InvokeAsync(i => i.Sum(numbers));
+            }
+
+			pipeClient.Dispose();
+		}
+
+		public static async Task RunServerAsync(PipeServer<IAdder> pipeServer)
+        {
+            await pipeServer.WaitForConnectionAsync();
+    
+			await pipeServer.WaitForRemotePipeCloseAsync();
+		}
+	}
+}

--- a/TestScenarioRunner/Program.cs
+++ b/TestScenarioRunner/Program.cs
@@ -96,7 +96,18 @@ switch (scenario)
             pipeClient.SetLogger(message => Console.WriteLine(message));
             await NoCallbackScenario.RunClientAsync(pipeClient);
         }
-
+        break;
+    case Scenario.Performance:
+        if (side == PipeSide.Server)
+        {
+            var pipeServer = new PipeServer<IAdder>(pipeSerializer, PipeName, () => new Adder());
+            await PerformanceScenario.RunServerAsync(pipeServer);
+        }
+        else
+        {
+            var pipeClient = new PipeClient<IAdder>(pipeSerializer, PipeName);
+            await PerformanceScenario.RunClientAsync(pipeClient);
+        }
         break;
     default:
         PrintUsage();


### PR DESCRIPTION
Hello,

The purpose of this PR is to improve project performance by avoiding the systematic call of the .Compile() method on the Expression class when the arguments are constant and can be resolved without compilation.

To achieve this, I have introduced a new class called ArgumentResolver that checks the arguments to determine if they are constant. If the arguments are not constant, the .Compile() method is called only in that specific case, eliminating unnecessary calls in other situations. This class is inspired from [this gist](https://gist.github.com/jcansdale/3d4b860188723ea346621b1c51fd8461)

This PR brings substantial performance improvements, typically resulting in a 75% to 80% reduction in execution time by eliminating unnecessary compilations.

It is not mandatory to keep the test project I added in my branch (you can only merge the first commit).

![perf](https://github.com/RandomEngy/PipeMethodCalls/assets/3192885/21ba0ba9-721d-4bd0-97a8-a98f391d0817)
