### PR TITLE
Use `AssemblyQualifiedName` instead of `ToString()` for the string representation of generic type arguments.

### DIFF
--- a/PipeMethodCalls/PipeStreamWrapper.cs
+++ b/PipeMethodCalls/PipeStreamWrapper.cs
@@ -112,7 +112,7 @@ namespace PipeMethodCalls
 					messageStream.WriteVarInt(request.GenericArguments.Length);
 					foreach (Type genericArgument in request.GenericArguments)
 					{
-						messageStream.WriteUtf8String(genericArgument.ToString());
+						messageStream.WriteUtf8String(genericArgument.AssemblyQualifiedName);
 					}
 				}
 				else
@@ -236,7 +236,7 @@ namespace PipeMethodCalls
 					for (int i = 0; i < genericArgumentCount; i++)
 					{
 						string genericArgumentString = messageStream.ReadUtf8String();
-						genericArguments[i] = Type.GetType(genericArgumentString);
+						genericArguments[i] = Type.GetType(genericArgumentString, throwOnError: true);
 					}
 
 					messageObject = new SerializedPipeRequest { CallId = callId, MethodName = methodName, Parameters = parameters, GenericArguments = genericArguments };


### PR DESCRIPTION
Without assembly information loading the type can fail on the receiving side.

Also, set `throwOnError` to `true` when loading the type on the receiving side, failing immediately if the type cannot be loaded. Without that, the generic argument is null which leads to a `NullReferenceException` much later (when looking up the type in the cache, which assumes keys are non-null), making it difficult to see the root cause.